### PR TITLE
Fix identify matching against binaries

### DIFF
--- a/identify
+++ b/identify
@@ -5,4 +5,4 @@ if [[ $# != 1 ]]; then
 fi
 libc=$1
 sha1=`sha1sum $libc`
-sha1sum db/*.so | grep $sha1
+sha1sum db/*.so | grep `echo $sha1 | awk '{print $1 }'`


### PR DESCRIPTION
The current version of 'identify' does not match when given a libc version which was added using the 'add' script. The filename stored in ./db/ is 'local-$sha1.so' however the libc version can be called something different which breaks matching.