### PR TITLE
Download from old-releases

### DIFF
--- a/common/libc.sh
+++ b/common/libc.sh
@@ -94,7 +94,7 @@ get_current_ubuntu() {
 get_all_ubuntu() {
   local info=$1
   local url=$2
-  for f in `wget $url/ -O - 2>/dev/null | egrep -oh 'libc6(-i386|-amd64)?_[^"]*' |grep -v "</a>"`; do
+  for f in `wget $url/ -O - 2>/dev/null | egrep -oh 'libc6(-i386|-amd64|_)[^"]*(i386|amd64)\.deb' |grep -v "</a>"`; do
     get_ubuntu $url/$f $1
   done
 }

--- a/get
+++ b/get
@@ -31,3 +31,5 @@ get_current_ubuntu bionic amd64 libc6-i386
 
 get_all_ubuntu archive-eglibc http://security.ubuntu.com/ubuntu/pool/main/e/eglibc/
 get_all_ubuntu archive-glibc http://security.ubuntu.com/ubuntu/pool/main/g/glibc/
+get_all_ubuntu archive-old-eglibc http://old-releases.ubuntu.com/ubuntu/pool/main/e/eglibc/
+get_all_ubuntu archive-old-glibc http://old-releases.ubuntu.com/ubuntu/pool/main/g/glibc/


### PR DESCRIPTION
I've noticed that some versions of libc get moved to http://old-releases.ubuntu.com and not remaining at http://security.ubuntu.com. Even versions from 2017 (2.24) are moved away.

Such versions are currently not downloaded by both `get_current_ubuntu` and `get_all_ubuntu`. This change in `get` script also looks up the old-releases.

A little change in a regex was necessary to filter out deb files for non-x86 architectures such as `libc6_2.24-3ubuntu2.2_powerpc.deb`.
