### PR TITLE
find libc by function offset delta

### DIFF
--- a/find-delta.py
+++ b/find-delta.py
@@ -1,0 +1,42 @@
+from sys import argv
+import os, re
+
+
+def usage():
+    print("%-7s %s %s" % ("usage:", argv[0], "[func1] [func2] [delta]"))
+    exit()
+
+
+def find_matches(arguments):
+    results = []
+    root_dir = "db" if len(os.path.dirname(argv[0])) == 0 else os.path.dirname(argv[0]) + "/db"
+
+    func1 = arguments[0]
+    func2 = arguments[1]
+    delta = int(arguments[2],16)
+
+    print("Looking for {} - {} = 0x{:x}".format(func1, func2, delta))
+
+    # Loop through all files and add files that match ALL arguments to results
+    for filename in os.listdir(root_dir):
+        if filename.endswith(".symbols"):
+            lines = open(root_dir + "/" + filename, "r").read().strip().split("\n")
+            offsets = {}
+            for line in lines:
+                split_line = line.split(" ")
+                offsets[split_line[0]] = int(split_line[1],16)
+            file_delta = offsets[func1] - offsets[func2]
+            if file_delta == delta:
+                print("{} {} - {} = 0x{:x}".format(filename, func1, func2, file_delta))
+                
+
+    return results
+
+
+if len(argv) < 4:
+    usage()
+
+for result in find_matches(argv[1:]):
+    print(result[0])
+    for line in result[1]:
+        print("  " + line.strip())


### PR DESCRIPTION
This allows to identify libc version by looking for a specific delta in symbol addresses, useful when all you got is leaked GOT adresses.
```
$ python find-delta.py puts fgets 1bc0 | grep amd64 | grep -v i386
libc6_2.23-0ubuntu10_amd64.symbols puts - fgets = 0x1bc0
libc6_2.29-0ubuntu2_amd64.symbols puts - fgets = 0x1bc0
libc6_2.23-0ubuntu11_amd64.symbols puts - fgets = 0x1bc0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/niklasb/libc-database/15)
<!-- Reviewable:end -->
