### PR TITLE
Add Debian support

### DIFF
--- a/common/libc.sh
+++ b/common/libc.sh
@@ -87,15 +87,21 @@ get_ubuntu() {
   rm -rf $tmp
 }
 
-get_current_ubuntu() {
+get_current_debian_like() {
   local version=$1
   local arch=$2
   local pkg=$3
-  local info=ubuntu-$version-$arch-$pkg
-  echo "Getting package location for ubuntu-$version-$arch"
-  local url=`(wget http://packages.ubuntu.com/$version/$arch/$pkg/download -O - 2>/dev/null \
+  local distro=$4
+  local website=$5
+  local info=$distro-$version-$arch-$pkg
+  echo "Getting package location for $distro-$version-$arch"
+  local url=`(wget $website/$version/$arch/$pkg/download -O - 2>/dev/null \
                | grep -oh 'http://[^"]*libc6[^"]*.deb') || die "Failed to get package version"`
   get_ubuntu $url $info
+}
+
+get_current_ubuntu() {
+  get_current_debian_like "$@" "ubuntu" "http://packages.ubuntu.com"
 }
 
 get_all_ubuntu() {
@@ -104,6 +110,12 @@ get_all_ubuntu() {
   for f in `wget $url/ -O - 2>/dev/null | egrep -oh 'libc6(-i386|-amd64)?_[^"]*(amd64|i386)\.deb' |grep -v "</a>"`; do
     get_ubuntu $url/$f $1
   done
+}
+
+# ===== Debian ===== #
+
+get_current_debian() {
+  get_current_debian_like "$@" "debian" "https://packages.debian.org"
 }
 
 # ===== Local ===== #

--- a/common/libc.sh
+++ b/common/libc.sh
@@ -95,8 +95,15 @@ get_current_debian_like() {
   local website=$5
   local info=$distro-$version-$arch-$pkg
   echo "Getting package location for $distro-$version-$arch"
-  local url=`(wget $website/$version/$arch/$pkg/download -O - 2>/dev/null \
-               | grep -oh 'http://[^"]*libc6[^"]*.deb') || die "Failed to get package version"`
+  local url=""
+  for i in $(seq 1 3); do
+    url=`(wget $website/$version/$arch/$pkg/download -O - 2>/dev/null \
+           | grep -oh 'http://[^"]*libc6[^"]*.deb')`
+    [[ -z "$url" ]] || break
+    echo "Retrying..."
+    sleep 1
+  done
+  [[ -n "$url" ]] || die "Failed to get package version"
   get_ubuntu $url $info
 }
 

--- a/get
+++ b/get
@@ -40,3 +40,15 @@ get_all_ubuntu archive-eglibc http://security.ubuntu.com/ubuntu/pool/main/e/egli
 get_all_ubuntu archive-glibc http://security.ubuntu.com/ubuntu/pool/main/g/glibc/
 get_all_ubuntu archive-old-eglibc http://old-releases.ubuntu.com/ubuntu/pool/main/e/eglibc/
 get_all_ubuntu archive-old-glibc http://old-releases.ubuntu.com/ubuntu/pool/main/g/glibc/
+
+debian_releases="
+jessie
+stretch
+buster
+bullseye
+"
+for debian_release in $debian_releases; do
+  get_current_debian "$debian_release" i386 libc6
+  get_current_debian "$debian_release" amd64 libc6
+  get_current_debian "$debian_release" amd64 libc6-i386
+done


### PR DESCRIPTION
CTFZone 2019 quals had a Debian glibc in one task, which gave me gray
hair. Let's make sure that doesn't happen to anyone again!

Test:
```
$ ./find recvfrom 6e0 sendto 9a0
http://http.us.debian.org/debian/pool/main/g/glibc/libc6_2.28-10_amd64.deb (id libc6_2.28-10_amd64)
```

With this change, Ubuntu still works:
```
$ ./find recvfrom 5d0 sendto 890
archive-glibc (id libc6_2.30-0ubuntu2_amd64)
```

Also:

Currently fetching Ubuntu package download page results in an
intermittent 500 error:
    
  https://bugs.launchpad.net/pkg-website/+bug/1854906
    
However, when working with libc-database, this creates an impression
that its link database is outdated. Work around this issue by trying
to fetch the page 3 times before giving up. In most cases, only 1
retry is needed.