### PR TITLE
Removed disco from ubuntu lists

### DIFF
--- a/get
+++ b/get
@@ -5,7 +5,6 @@ cd "$(dirname "$0")"
 ubuntu_versions=(
     xenial
     bionic
-    disco
     eoan
     focal
 )


### PR DESCRIPTION
https://packages.ubuntu.com/ says:
```
2020-05-04
Reflect focal release, add groovy, remove disco.
```