### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ works on page size level.
     $ ./find printf 260 puts f30
     archive-glibc (id libc6_2.19-10ubuntu2_i386)
 
-Find a libc from the leaked return address into __libc_start_main.
+Find a libc from the leaked return address into `__libc_start_main`.
 
     $ ./find __libc_start_main_ret a83
     ubuntu-trusty-i386-libc6 (id libc6_2.19-0ubuntu6.6_i386)

--- a/common/libc.sh
+++ b/common/libc.sh
@@ -40,7 +40,7 @@ process_libc() {
   local id=$2
   local info=$3
   local url=$4
-  echo "  -> Writing libc to db/${id}.so"
+  echo "  -> Writing libc ${libc} to db/${id}.so"
   cp $libc db/${id}.so
   echo "  -> Writing symbols to db/${id}.symbols"
   (dump_symbols $libc; dump_libc_start_main_ret $libc; dump_bin_sh $libc) \

--- a/common/libc.sh
+++ b/common/libc.sh
@@ -98,7 +98,7 @@ get_current_debian_like() {
   local url=""
   for i in $(seq 1 3); do
     url=`(wget $website/$version/$arch/$pkg/download -O - 2>/dev/null \
-           | grep -oh 'http://[^"]*libc6[^"]*.deb')`
+           | grep -oh 'http://[^"]*libc6[^"]*\.deb')`
     [[ -z "$url" ]] || break
     echo "Retrying..."
     sleep 1


### PR DESCRIPTION
Various fix:

* Format a technical term in `README.md`
* Add the path to the processed libc in `process_libc` (`common/libc.sh`)
* Escape a `.` on a regex (here it does not provoke a bug, but it's more clean) in `get_current_debian_like` (`common/libc.sh`)