### PR TITLE
Simplify Ubuntu and Debian monitoring

### DIFF
--- a/common/libc.sh
+++ b/common/libc.sh
@@ -59,9 +59,9 @@ check_id() {
   return 0
 }
 
-# ===== Ubuntu ===== #
+# ===== Debian-like ===== #
 
-get_ubuntu() {
+get_debian() {
   local url="$1"
   local info="$2"
   local tmp=`mktemp -d`
@@ -87,42 +87,12 @@ get_ubuntu() {
   rm -rf $tmp
 }
 
-get_current_debian_like() {
-  local version=$1
-  local arch=$2
-  local pkg=$3
-  local distro=$4
-  local website=$5
-  local info=$distro-$version-$arch-$pkg
-  echo "Getting package $pkg location for $distro-$version-$arch"
-  local url=""
-  for i in $(seq 1 3); do
-    url=`(wget $website/$version/$arch/$pkg/download -O - 2>/dev/null \
-           | grep -oh 'http://[^"]*libc6[^"]*\.deb')`
-    [[ -z "$url" ]] || break
-    echo "Retrying..."
-    sleep 1
-  done
-  [[ -n "$url" ]] || die "Failed to get package version"
-  get_ubuntu $url $info
-}
-
-get_current_ubuntu() {
-  get_current_debian_like "$@" "ubuntu" "http://packages.ubuntu.com"
-}
-
-get_all_ubuntu() {
+get_all_debian() {
   local info=$1
   local url=$2
   for f in `wget $url/ -O - 2>/dev/null | egrep -oh 'libc6(-i386|-amd64)?_[^"]*(amd64|i386)\.deb' |grep -v "</a>"`; do
-    get_ubuntu $url/$f $1
+    get_debian $url/$f $1
   done
-}
-
-# ===== Debian ===== #
-
-get_current_debian() {
-  get_current_debian_like "$@" "debian" "https://packages.debian.org"
 }
 
 # ===== Local ===== #

--- a/get
+++ b/get
@@ -2,22 +2,11 @@
 cd "$(dirname "$0")"
 . common/libc.sh
 
-ubuntu_versions=(
-    xenial
-    bionic
-    eoan
-    focal
-)
-
-for version in ${ubuntu_versions[@]}; do
-    get_current_ubuntu $version amd64 libc6
-    get_current_ubuntu $version amd64 libc6-i386
-    get_current_ubuntu $version i386 libc6
-done
-
-get_all_ubuntu archive-eglibc http://security.ubuntu.com/ubuntu/pool/main/e/eglibc/
-get_all_ubuntu archive-glibc http://security.ubuntu.com/ubuntu/pool/main/g/glibc/
-get_all_ubuntu archive-old-eglibc http://old-releases.ubuntu.com/ubuntu/pool/main/e/eglibc/
-get_all_ubuntu archive-old-glibc http://old-releases.ubuntu.com/ubuntu/pool/main/g/glibc/
+get_all_ubuntu ubuntu-eglibc http://archive.ubuntu.com/ubuntu/pool/main/e/eglibc/
+get_all_ubuntu ubuntu-glibc http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/
+get_all_ubuntu ubuntu-security-eglibc http://security.ubuntu.com/ubuntu/pool/main/e/eglibc/
+get_all_ubuntu ubuntu-security-glibc http://security.ubuntu.com/ubuntu/pool/main/g/glibc/
+get_all_ubuntu ubuntu-old-eglibc http://old-releases.ubuntu.com/ubuntu/pool/main/e/eglibc/
+get_all_ubuntu ubuntu-old-glibc http://old-releases.ubuntu.com/ubuntu/pool/main/g/glibc/
 
 get_all_ubuntu debian-glibc https://deb.debian.org/debian/pool/main/g/glibc

--- a/get
+++ b/get
@@ -2,11 +2,11 @@
 cd "$(dirname "$0")"
 . common/libc.sh
 
-get_all_ubuntu ubuntu-eglibc http://archive.ubuntu.com/ubuntu/pool/main/e/eglibc/
-get_all_ubuntu ubuntu-glibc http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/
-get_all_ubuntu ubuntu-security-eglibc http://security.ubuntu.com/ubuntu/pool/main/e/eglibc/
-get_all_ubuntu ubuntu-security-glibc http://security.ubuntu.com/ubuntu/pool/main/g/glibc/
-get_all_ubuntu ubuntu-old-eglibc http://old-releases.ubuntu.com/ubuntu/pool/main/e/eglibc/
-get_all_ubuntu ubuntu-old-glibc http://old-releases.ubuntu.com/ubuntu/pool/main/g/glibc/
+get_all_debian ubuntu-eglibc http://archive.ubuntu.com/ubuntu/pool/main/e/eglibc/
+get_all_debian ubuntu-glibc http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/
+get_all_debian ubuntu-security-eglibc http://security.ubuntu.com/ubuntu/pool/main/e/eglibc/
+get_all_debian ubuntu-security-glibc http://security.ubuntu.com/ubuntu/pool/main/g/glibc/
+get_all_debian ubuntu-old-eglibc http://old-releases.ubuntu.com/ubuntu/pool/main/e/eglibc/
+get_all_debian ubuntu-old-glibc http://old-releases.ubuntu.com/ubuntu/pool/main/g/glibc/
 
-get_all_ubuntu debian-glibc https://deb.debian.org/debian/pool/main/g/glibc
+get_all_debian debian-glibc https://deb.debian.org/debian/pool/main/g/glibc

--- a/get
+++ b/get
@@ -20,14 +20,4 @@ get_all_ubuntu archive-glibc http://security.ubuntu.com/ubuntu/pool/main/g/glibc
 get_all_ubuntu archive-old-eglibc http://old-releases.ubuntu.com/ubuntu/pool/main/e/eglibc/
 get_all_ubuntu archive-old-glibc http://old-releases.ubuntu.com/ubuntu/pool/main/g/glibc/
 
-debian_versions=(
-    jessie
-    stretch
-    buster
-    bullseye
-)
-for version in ${debian_versions[@]}; do
-  get_current_debian $version i386 libc6
-  get_current_debian $version amd64 libc6
-  get_current_debian $version amd64 libc6-i386
-done
+get_all_ubuntu debian-glibc https://deb.debian.org/debian/pool/main/g/glibc


### PR DESCRIPTION
Instead of searching libc for each version, it will index all those available.