### PR TITLE
Fix `identify`

### DIFF
--- a/identify
+++ b/identify
@@ -45,4 +45,4 @@ case "$arg" in
     help
 esac
 
-ls -1 db/*.so | xargs $tool | grep -- "$regex" | perl -n -e '/db\/(.*)\.so:.*/&&print "id $1\n"'
+ls -1 db/*.so | xargs $tool | grep -- "$regex" | perl -n -e '/db\/([^ ]*)\.so/&&print "id $1\n"'


### PR DESCRIPTION
This bug was introduced in 34e25ee, merged in #22 and reported in #24.

It's very strange: I tested on a Fedora, it was working, and, on a Debian, it failed… Have to investigate…