### PR TITLE
Fix numerical comparison in ./find

### DIFF
--- a/find
+++ b/find
@@ -15,7 +15,7 @@ function find_single() {
 }
 
 function find() {
-  [[ $# < 2 ]] && usage
+  [[ $# -lt 2 ]] && usage
   name=$1; shift
   address=$1; shift
   if [[ $# == 0 ]]; then


### PR DESCRIPTION
Originally, `[[ a < b ]]` did lexical comparison; so having e.g. 10 arguments to `./find` would result in the Usage message appearing.

Test command:
```sh
~ $ ./find puts 0xf7d76290 __libc_start_main 0xf0f7d762 setvbuf 0x3df0f7d7 putchar 0xd23df0f7 __isoc99_scanf 0xf7d23df0
Usage: ./libc-database/find name address [name address ...]
```
