### PR TITLE
Add Pwntools API

### DIFF
--- a/searchengine/api.yml
+++ b/searchengine/api.yml
@@ -54,6 +54,39 @@ paths:
                 $ref: '#/components/schemas/Libc'
           description: ''
 
+  /hashes/{hashtype}/{hash}:
+    get:
+      operationId: app.hashes
+      tags:
+        - libcsearch
+      parameters:
+        - in: path
+          name: hashtype
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: hash
+          schema:
+            type: string
+          required: true
+      description: >-
+        Get the download link using a hash. Implemented for pwntools
+        compatibility.
+      responses:
+        '200':
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                Link to the libc binary file:
+                  value: 'https://link/to/binary.so'
+                Library not found:
+                  value: ''
+          description: Link to the libc binary file
+
+
 components:
   schemas:
     Libc:

--- a/searchengine/app.py
+++ b/searchengine/app.py
@@ -10,6 +10,7 @@ import config
 
 es = Elasticsearch(hosts=[config.ES_HOST])
 log = logging.getLogger('wsgi')
+hashtypes = ['md5', 'sha1', 'sha256', 'buildid']
 
 log.info(f'Using elasticsearch server {config.ES_HOST}, index {config.ES_INDEX_NAME}')
 
@@ -30,7 +31,7 @@ def get_symbols(id):
 def find(body, extra_symbols=[]):
     filters = []
 
-    for h in ('id', 'md5', 'sha1', 'sha256', 'buildid'):
+    for h in hashtypes + ['id']:
         if h in body:
             filters.append({'match': {h: body[h]}})
 
@@ -90,6 +91,29 @@ def dump(id, body):
         )
 
     return res[0]
+
+
+def hashes(hashtype, hash):
+    """
+    Will return an URL to download the wanted binary
+    """
+    hashtype = hashtype.lower()
+    hash = hash.lower()
+    if hashtype not in hashtypes:
+        return connexion.problem(
+            status=404,
+            title='Not found',
+            detail=f'Unknown hashtype: {hashtype}'
+        )
+    res = find({hashtype: hash})
+    if not res:
+        return connexion.problem(
+            status=404,
+            title='Not found',
+            detail=f'Unknown hash: {hash}'
+        )
+
+    return res[0]['download_url']
 
 
 app = connexion.App(__name__, specification_dir='.')


### PR DESCRIPTION
In order to add the ability to integrate this search engine in pwntools, these changes aims to add endpoints used by pwntools.