### PR TITLE
make identify position independent

### DIFF
--- a/identify
+++ b/identify
@@ -16,8 +16,13 @@ fi
 
 arg="$1"
 
-if [[ -f "$arg" ]]; then
-  libc=$arg
+if [ "${1:0:1}" != "/" ]; then    # this is a relative path
+  libc="$OLDPWD"/"$arg"
+else
+  libc="$arg"
+fi
+
+if [[ -f "$libc" ]]; then
   arg="sha1=$(sha1sum "$libc" | awk '{print $1}')"
 fi
 

--- a/identify
+++ b/identify
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o pipefail
-cd "$(dirname "$0")"
 help() {
   echo >&2 "Usage: $0 path/to/libc.so"
   echo >&2 "    OR $0 bid=<BUILD_ID>"
@@ -16,11 +15,11 @@ fi
 
 arg="$1"
 
-if [ "${1:0:1}" != "/" ]; then    # this is a relative path
-  libc="$OLDPWD"/"$arg"
-else
-  libc="$arg"
+if [ -f "$arg" ]; then
+  libc="$(readlink -f "$arg")"
 fi
+
+cd "$(dirname "$0")"
 
 if [[ -f "$libc" ]]; then
   arg="sha1=$(sha1sum "$libc" | awk '{print $1}')"


### PR DESCRIPTION
Ideally, if `identify` is executed in directory `/different/path`, a relative `path/to/libc.so` should be sourced from `/different/path`.

Current behaviour: 
```
/different/path$ /path/to/libc-database/identify ./libc.so.6
Usage: /path/to/libc-database/identify path/to/libc.so
    OR /path/to/libc-database/identify bid=<BUILD_ID>
    OR /path/to/libc-database/identify md5=<MD5>
    OR /path/to/libc-database/identify sha1=<SHA1>
    OR /path/to/libc-database/identify sha256=<SHA256>
```
Expected & new behaviour:
```
/different/path$ /path/to/libc-database/identify ./libc.so.6
libc6_2.27-3ubuntu1.2_amd64
```

normal test cases to make sure nothing broke:
```
/path/to/libc-database$ ./identify db/libc6_2.27-3ubuntu1.2_amd64.so
libc6_2.27-3ubuntu1.2_amd64
/path/to/libc-database$ ./identify /path/to/libc-database/db/libc6_2.27-3ubuntu1.2_amd64.so
libc6_2.27-3ubuntu1.2_amd64
/different/path$ /path/to/libc-database/identify /different/path/libc.so.6
libc6_2.27-3ubuntu1.2_amd64
```
