### PR TITLE
-e --> -f

### DIFF
--- a/common/libc.sh
+++ b/common/libc.sh
@@ -292,7 +292,7 @@ requirements_pkg() {
 
 add_local() {
   local libc=$1
-  [[ -e $libc ]] || return
+  [[ -f $libc ]] || return
   local info="local"
   local id="local-`sha1sum $libc`"
   echo "Adding local libc $libc (id $id)"


### PR DESCRIPTION
A lot of Bad Things happen if someone accidentally `./add`s a directory (instead of a normal file):
```bash
$ ./add .
sha1sum: /path/to/A/libc-database: Is a directory
Adding local libc /path/to/A/libc-database (id local-)
  -> Writing libc /path/to/A/libc-database to db/local-.so
cp: -r not specified; omitting directory '/path/to/A/libc-database'
  -> Writing symbols to db/local-.symbols
readelf: Error: '/path/to/A/libc-database' is not an ordinary file
objdump: Warning: '/path/to/A/libc-database' is not an ordinary file
objdump: Warning: '/path/to/A/libc-database' is not an ordinary file
  -> Writing version info
```

`-f` will check for a regular file, instead of an arbitrary file (`-e`)