### PR TITLE
Add Ubuntu packages from Launchpad #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ To run these scripts, you will need following command on your PATH:
 
 ### CentOS-based
 
-In addition of RPM-Based requirements, you will need:
+In addition to the RPM-Based requirements, you will need:
 
 * wget
 * gzip
@@ -146,6 +146,13 @@ In addition of RPM-Based requirements, you will need:
 * grep
 
 
+### Launchpad-based
+
+In addition to the Debian-based requirements, you will need:
+
+* jq
+
+
 ### Install everything
 
 To install everything on Debian 10, run these commands:
@@ -156,7 +163,7 @@ apt-get install -y \
   binutils file \
   wget \
   rpm2cpio cpio \
-  zstd
+  zstd jq
 ```
 
 

--- a/get
+++ b/get
@@ -104,7 +104,13 @@ parrotsec() {
   get_all_debian parrotsec-glibc https://download.parrot.sh/parrot/pool/main/g/glibc/ libc6
   get_all_debian parrotsec-musl https://download.parrot.sh/parrot/pool/main/m/musl/ musl
 }
-
+categories[cntr_category]="launchpad"
+requirements["launchpad"]="requirements_launchpad"
+cntr_category=$((cntr_category + 1))
+launchpad() {
+  get_all_launchpad launchpad-ubuntu-glibc ubuntu libc6 amd64
+  get_all_launchpad launchpad-ubuntu-glibc ubuntu libc6 i386
+}
 
 help() {
   exec 1>&2


### PR DESCRIPTION
This adds all libc6 versions from the ubuntu distro on launchpad.net.

It is quite a list, so maybe we should switch back to manually listing the versions instead of blindly installing all of them.
A few of the really old ones like maverick seem to have the release packages deleted too, so download failures are allowed.

I've tried to keep the request load on the API as low as possible and I couldn't find a way to have it return download urls for the binary packages anyway. So this compiles the download url based on available info in the API manually which is why some of the downloads might fail.

```
"groovy"
"focal"
"eoan"
"disco"
"cosmic"
"bionic"
"artful"
"zesty"
"yakkety"
"xenial"
"wily"
"vivid"
"utopic"
"trusty"
"saucy"
"raring"
"quantal"
"precise"
"oneiric"
"natty"
"maverick"
"lucid"
"karmic"
"jaunty"
"intrepid"
"hardy"
"gutsy"
"feisty"
"edgy"
"dapper"
"breezy"
"hoary"
"warty"
```

Fixes #28