### PR TITLE
Add debug symbols to ./download

### DIFF
--- a/download
+++ b/download
@@ -11,6 +11,19 @@ usage() {
   exit 2
 }
 
+extract_package(){
+  # expect: url
+  # result: package from url is extracted into $tmp. runtime is cd'd into $tmp; caller expected to popd out.
+  echo "  -> Location: $1"
+  local tmp=`mktemp -d`
+  echo "  -> Downloading package"
+  wget "$1" 2>/dev/null -O "$tmp/pkg.deb" || die "Failed to download package from $1"
+  echo "  -> Extracting package"
+
+  pushd "$tmp" 1>/dev/null
+  ar x pkg.deb || die "ar failed"
+}
+
 download_single() {
   local id=$1
   echo "Getting $id"
@@ -23,15 +36,9 @@ download_single() {
   fi
 
   local url="$(cat "db/$1.url")"
-  echo "  -> Location: $url"
-  local tmp=`mktemp -d`
-  echo "  -> Downloading package"
-  wget "$url" 2>/dev/null -O $tmp/pkg.deb || die "Failed to download package from $url"
-  echo "  -> Extracting package"
-
-  pushd $tmp 1>/dev/null
-  ar x pkg.deb || die "ar failed"
+  extract_package "$url"
   tar xf data.tar.* || die "tar failed"
+  local tmp="$PWD"
   popd 1>/dev/null
 
   mkdir libs/$id
@@ -39,10 +46,59 @@ download_single() {
     || die "Failed to save. Check it manually $tmp"
   echo "  -> Package saved to libs/$id"
 
+  [ -z "$tmp" ] && die '!! $tmp was null !!'
   rm -rf $tmp
+}
+download_source() {
+  # expect: id (e.g. libc6_2.15-0ubuntu10.18_amd64)
+  # result: downloads source files & debug .so files
+  # stored at ./libs/$orig_id/(debug|source).
+  local orig_id="$1"
+  local trimmed_id="$(grep -o '_.*' <<< "$1")" # id without the pkgname
+  local ver="$(sed 's/_\(2\.[0-9]*\).*/\1/' <<< "$trimmed_id")" # e.g. "2.15"
+  local source_id="glibc-source$(sed 's/[0-9a-z]*$/all/' <<< "$trimmed_id")" # need to replace _(amd64|i386|...) with _all
+  local debug_id="libc6-dbg$trimmed_id"
+
+  echo "Getting debug materials for $orig_id"
+  if [ -d "libs/$orig_id/source" ] || [ -d "libs/$orig_id/debug" ]; then
+      die "  --> Downloaded before. Remove 'libs/$orig_id/source' to download again."
+  fi
+
+  local urlbase="$(grep -o '.*/' "db/$orig_id.url")"
+  local source_url="$(sed 's/main/universe/' <<< "$urlbase")$source_id.deb"
+  local debug_url="$urlbase$debug_id.deb"
+
+  # get sources
+  extract_package "$source_url"
+  tar --wildcards -xf data.tar.* "./usr/src/glibc/glibc-*" || die "tar failed"
+  tar xf ./usr/src/glibc/glibc-* || die "tar failed"
+  local tmp="$PWD"
+  popd 1>/dev/null
+
+  mkdir "libs/$orig_id/source"
+  mv "$tmp/glibc-$ver" "libs/$orig_id/source"
+  [ -z "$tmp" ] && die '!! $tmp was null !!'
+  rm -rf "$tmp"
+
+  # get debug symbols
+  extract_package "$debug_url"
+  tar xf data.tar.* || die "tar failed"
+  local tmp="$PWD"
+  popd 1>/dev/null
+
+  mkdir "libs/$orig_id/debug"
+  mv "$tmp/usr/lib/debug/lib" "$tmp/lib"  # /lib should not exist
+  cp $tmp/lib/*/* libs/$orig_id/debug 2>/dev/null || cp $tmp/lib32/* libs/$orig_id/debug 2>/dev/null \
+    || die "Failed to save. Check it manually $tmp"
+  ln libs/$orig_id/debug/libc-$ver.so libs/$orig_id/debug/libc.so.6
+  [ -z "$tmp" ] && die '!! $tmp was null !!'
+  rm -rf "$tmp"
 }
 
 if [[ $# != 1 ]]; then
   usage
 fi
 download_single "$1"
+if grep -q ubuntu <<< "$1"; then
+  download_source "$1"
+fi


### PR DESCRIPTION
This is a tentative attempt at automating the process of grabbing debug `.so`s and libc sources, which are useful for [providing source-level libc debugging in gdb](https://github.com/yannayl/glibc_malloc_for_exploiters/blob/gh-pages/markdown/setup.md).

The scope of this PR is limited to **ubuntu only**; non-apt-based libc packages are _really_ outside of my knowledge and I'd rather not attempt that. I tried checking debian packages but a lot of their `libc6-dbg` packages only contain `.debug` files that I don't really know what to do with. 

The added code has also **not been extensively tested**. It might work on my machine, but bash is notoriously easy to mess up. Here's an example of what a correct run might look like:
```sh
~/libc-database$ ./download libc6_2.27-3ubuntu1_amd64
Getting libc6_2.27-3ubuntu1_amd64
  -> Location: http://security.ubuntu.com/ubuntu/pool/main/g/glibc//libc6_2.27-3ubuntu1_amd64.deb
  -> Downloading package
  -> Extracting package
  -> Package saved to libs/libc6_2.27-3ubuntu1_amd64
Getting debug materials for libc6_2.27-3ubuntu1_amd64
  -> Location: http://security.ubuntu.com/ubuntu/pool/universe/g/glibc//glibc-source_2.27-3ubuntu1_all.deb
  -> Downloading package
  -> Extracting package
  -> Location: http://security.ubuntu.com/ubuntu/pool/main/g/glibc//libc6-dbg_2.27-3ubuntu1_amd64.deb
  -> Downloading package
  -> Extracting package
~/libc-database$ ls libs/libc6_2.27-3ubuntu1_amd64
debug                 libBrokenLocale-2.27.so  libcrypt-2.27.so  libm-2.27.so     libnsl-2.27.so         libnss_dns.so.2        libnss_nis-2.27.so      libpthread-2.27.so  librt.so.1           libutil.so.1
ld-2.27.so            libBrokenLocale.so.1     libcrypt.so.1     libmemusage.so   libnsl.so.1            libnss_files-2.27.so   libnss_nisplus-2.27.so  libpthread.so.0     libSegFault.so       source
ld-linux-x86-64.so.2  libc-2.27.so             libc.so.6         libm.so.6        libnss_compat-2.27.so  libnss_files.so.2      libnss_nisplus.so.2     libresolv-2.27.so   libthread_db-1.0.so
libanl-2.27.so        libcidn-2.27.so          libdl-2.27.so     libmvec-2.27.so  libnss_compat.so.2     libnss_hesiod-2.27.so  libnss_nis.so.2         libresolv.so.2      libthread_db.so.1
libanl.so.1           libcidn.so.1             libdl.so.2        libmvec.so.1     libnss_dns-2.27.so     libnss_hesiod.so.2     libpcprofile.so         librt-2.27.so       libutil-2.27.so
~/libc-database$ ls libs/libc6_2.27-3ubuntu1_amd64/debug/
ld-2.27.so               libc-2.27.so      libdl-2.27.so   libmvec-2.27.so        libnss_dns-2.27.so     libnss_nis-2.27.so      libresolv-2.27.so  libthread_db-1.0.so
libanl-2.27.so           libcidn-2.27.so   libm-2.27.so    libnsl-2.27.so         libnss_files-2.27.so   libnss_nisplus-2.27.so  librt-2.27.so      libutil-2.27.so
libBrokenLocale-2.27.so  libcrypt-2.27.so  libmemusage.so  libnss_compat-2.27.so  libnss_hesiod-2.27.so  libpcprofile.so         libSegFault.so
~/libc-database$ ls libs/libc6_2.27-3ubuntu1_amd64/source/
glibc-2.27
~/libc-database$ ls libs/libc6_2.27-3ubuntu1_amd64/source/glibc-2.27/
abi-tags    ChangeLog       COPYING      dlfcn           gnulib     include    libio              mach         manual   nptl_db        README    shadow          streams  test-skeleton.c
aclocal.m4  ChangeLog.old   COPYING.LIB  elf             grp        inet       libof-iterator.mk  MAINTAINERS  math     nscd           resolv    shlib-versions  string   time
argp        config.h.in     crypt        extra-lib.mk    gshadow    INSTALL    libpthread         Makeconfig   mathvec  nss            resource  signal          sunrpc   timezone
assert      config.make.in  csu          fbtl            hesiod     intl       LICENSES           Makefile     misc     o-iterator.mk  rt        socket          support  version.h
benchtests  configure       ctype        fbtl_db         hurd       io         locale             Makefile.in  NEWS     po             Rules     soft-fp         sysdeps  wcsmbs
bits        configure.ac    debug        gen-locales.mk  iconv      libc-abis  localedata         Makerules    nis      posix          scripts   stdio-common    sysvipc  wctype
catgets     conform         dirent       gmon            iconvdata  libidn     login              malloc       nptl     pwd            setjmp    stdlib          termios
```
Any feedback is welcome.