### PR TITLE
Handle zstd within debian packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ To run these scripts, you will need following command on your PATH:
 * ar
 * tar
 * grep
+* zstd
 
 
 ### RPM-based (category 'rpm')

--- a/common/libc.sh
+++ b/common/libc.sh
@@ -111,7 +111,12 @@ get_debian() {
   echo "  -> Extracting package"
   pushd $tmp 1>/dev/null
   ar x pkg.deb || die "ar failed"
-  tar xf data.tar.* || die "tar failed"
+  if [ -f data.tar.zst ]; then
+    zstd -d data.tar.zst || die "zstd failed"
+    tar xf data.tar || die "tar failed"
+  else
+    tar xf data.tar.* || die "tar failed"
+  fi
   popd 1>/dev/null
   index_libc "$tmp" "$id" "$info" "$url"
   rm -rf $tmp
@@ -134,6 +139,7 @@ requirements_debian() {
   which ar     1>/dev/null 2>&1 || return
   which tar    1>/dev/null 2>&1 || return
   which grep   1>/dev/null 2>&1 || return
+  which zstd   1>/dev/null 2>&1 || return
   return 0
 }
 


### PR DESCRIPTION
Some ubuntu .deb packages contain data.tar.zst file. One example is http://archive.ubuntu.com/ubuntu/pool/main/g/glibc//libc6-amd64_2.33-0ubuntu9_i386.deb.

The .tar.zst may not be automatically uncompressed by the `tar xf` command, failing the `./get`.

This patch explicitly handles data.tar.zst in deb downloads and add `zstd` as a requirement.
