### PR TITLE
Retry rpm download with --no-dns-cache

### DIFF
--- a/common/libc.sh
+++ b/common/libc.sh
@@ -156,7 +156,7 @@ get_rpm() {
   echo "  -> ID: $id"
   check_id "$id" || return
   echo "  -> Downloading package"
-  if ! wget "$url" 2>/dev/null -O "$tmp/pkg.rpm"; then
+  if ! wget --no-dns-cache --connect-timeout=30 "$url" 2>/dev/null -O "$tmp/pkg.rpm"; then
     echo >&2 "Failed to download package from $url"
     return
   fi


### PR DESCRIPTION
Retry in `get_rpm()` without dns cache.

Unlike other distros, CentOS download site uses something like round-robin DNS. The mirror.centos.org domain maps to one of many IPs. Sometimes an IP can be too slow or unreachable for some reason. In my case, `147.75.93.107` is unreachable from my location (South Korea).

`wget` automatically retries on such network failure, but with DNS cached. The solution to this problem is either
1. Restart wget process, as in `get_from_filelistgz()`. wget's DNS cache is only in memory.
2. Use `--no-dns-cache` option that tells wget to use different IP every retry.

This patch applies (2) to `get_rpm()`.

A quick test show that the retry makes the download more robust.

```
#10 16.06 Getting centos-glibc
#10 16.06   -> Location: http://mirror.centos.org/centos//./7.9.2009/updates/x86_64/Packages/glibc-2.17-323.el7_9.i686.rpm
#10 16.07   -> ID: glibc-2.17-323.el7_9.i686
#10 16.07   -> Downloading package
#10 16.07 --2021-08-15 02:33:04--  http://mirror.centos.org/centos//7.9.2009/updates/x86_64/Packages/glibc-2.17-323.el7_9.i686.rpm
#10 16.07 Resolving mirror.centos.org (mirror.centos.org)... 147.75.93.107, 2604:1380:3000:2800::1
#10 16.58 Connecting to mirror.centos.org (mirror.centos.org)|147.75.93.107|:80... failed: Connection timed out.
#10 46.58 Connecting to mirror.centos.org (mirror.centos.org)|2604:1380:3000:2800::1|:80... failed: Cannot assign requested address.
#10 46.58 Retrying.
#10 46.58
#10 47.58 --2021-08-15 02:33:35--  (try: 2)  http://mirror.centos.org/centos//7.9.2009/updates/x86_64/Packages/glibc-2.17-323.el7_9.i686.rpm
#10 47.58 Resolving mirror.centos.org (mirror.centos.org)... 160.116.15.18, 2406:da1a:fcb:2f01:b6e2:c6:795:b503
#10 48.00 Connecting to mirror.centos.org (mirror.centos.org)|160.116.15.18|:80... connected.
#10 48.30 HTTP request sent, awaiting response... 200 OK
#10 48.61 Length: 4465468 (4.3M) [application/x-rpm]
#10 48.61 Saving to: ‘/tmp/tmp.hTApue5xnM/pkg.rpm’
#10 48.61
#10 48.61      0K .......... .......... .......... .......... ..........  1% 1.64M 3s
#10 48.64     50K .......... .......... .......... .......... ..........  2% 10.8M 1s
``` 

This feature may be applied to other download functions like `get_debian()`, but this problem seems unlikely in other download sites.