### PR TITLE
Fix __libc_start_main_ret lookup with glibc 2.34

### DIFF
--- a/common/libc.sh
+++ b/common/libc.sh
@@ -22,6 +22,16 @@ dump_libc_start_main_ret() {
     | grep -EB 1 '<exit.*>' \
     | head -n 1 \
     | extract_label`
+  # Since glibc 2.34 it's __libc_start_main -> __libc_start_call_main -> main
+  # and __libc_start_call_main is right before __libc_start_main.
+  if [[ "$call_main" == "" ]]; then
+    local call_main=`objdump -D $1 \
+      | grep -EB 100 '<__libc_start_main.*>' \
+      | grep call \
+      | grep -EB 1 '<exit.*>' \
+      | head -n 1 \
+      | extract_label`
+  fi
   local offset=`objdump -D $1 | grep -EA 1 "(^| )$call_main:" | tail -n 1 | extract_label`
   if [[ "$offset" != "" ]]; then
     echo "__libc_start_main_ret $offset"


### PR DESCRIPTION
`__libc_start_main` doesn't call `main` directly anymore but uses a wrapper helper.
That helper `__libc_start_call_main` is right above `__libc_start_main`, so look above the function if below fails to find an `exit` call.

Instead of doing `grep -C` to grab context above and below `__libc_start_main` directly, I've opted to only check above if below didn't work in an attempt to not potentially break some other binaries.

https://sourceware.org/git/?p=glibc.git;a=commit;h=130fca173f323a24b41873b6656ab77c7cff86e1