### PR TITLE
Add automatic downloading of debug symbols and patch elf command

### DIFF
--- a/common/libc.sh
+++ b/common/libc.sh
@@ -202,6 +202,7 @@ get_debian_debug_symbols() {
   fi
   popd 1>/dev/null
   index_debug $tmp $id
+  rm -rf $tmp
 }
 
 get_all_debian() {

--- a/common/libc.sh
+++ b/common/libc.sh
@@ -54,7 +54,7 @@ process_lib() {
   echo "  -> Writing binary $lib to db/${id}/"
   mkdir -p db/${id}/
   cp $lib db/${id}/$(basename $lib)$suffix
-  if [[ $lib =~ .*libc[0-9\._]*\.so.* ]]; then
+  if [[ $lib =~ .*libc[-_\.][0-9\._a-zA-Z]*\.so.* ]]; then
     echo "  -> Writing symbols to db/${id}/"
     (dump_symbols $lib; dump_libc_start_main_ret $lib; dump_bin_sh $lib)  > db/${id}/"$(basename $lib)$suffix".symbols
   fi

--- a/dump
+++ b/dump
@@ -12,9 +12,16 @@ if [[ $# == 0 ]]; then
 else
   names="$@"
 fi
-ls -1 "db/${id}."* >/dev/null 2>&1 || die "Invalid ID '$id'"
+
+ls -1 "db/${id}" >/dev/null 2>&1 || die "Invalid ID '$id'"
 for name in $names; do
-  offset=`cat db/${id}.symbols | grep "^$name " | cut -d' ' -f2`
-  [ -z "$offset" ] && die "Invalid symbol '$name'"
-  echo "offset_${name} = 0x${offset}"
+  found=0
+  ls db/${id}/*.symbols | while read file; do
+    offset=`cat $file | grep "^$name " | cut -d ' ' -f2`
+	[ -z "$offset" ] && continue
+	echo "offset_$name in " ${id::-7}.so = "0x${offset}"
+	found=1
+  done
+  [ -z $found ] && die "No symbol $name found in libraries."
 done
+

--- a/find
+++ b/find
@@ -9,8 +9,8 @@ function find_single() {
   name=$1
   address=$2
   addr_last12=`echo -n "$address" | tail -c 3`
-  grep -i -e "^$name .*$addr_last12$" db/*.symbols \
-    | perl -n -e '/db\/(.*)\.symbols/ && print "$1\n"' \
+  grep -i -e "^$name .*$addr_last12$" db/*/*.symbols \
+    | perl -n -e '/db\/.*\/(.*)\.symbols/ && print "$1\n"' \
     | sort
 }
 
@@ -29,7 +29,7 @@ function find() {
 
 ret=1
 for id in `find "$@"`; do
-  echo "`cat db/${id}.info` ($id)"
+  echo "`cat db/${id}/info` ($id)"
   ret=0
 done
 exit $ret

--- a/find
+++ b/find
@@ -10,7 +10,7 @@ function find_single() {
   address=$2
   addr_last12=`echo -n "$address" | tail -c 3`
   grep -i -e "^$name .*$addr_last12$" db/*/*.symbols \
-    | perl -n -e '/db\/.*\/(.*)\.symbols/ && print "$1\n"' \
+    | perl -n -e '/db\/(.*)\/.*\.symbols/ && print "$1\n"' \
     | sort
 }
 

--- a/get
+++ b/get
@@ -49,16 +49,16 @@ categories[cntr_category]="centos"
 requirements["centos"]="requirements_centos"
 cntr_category=$((cntr_category + 1))
 centos() {
-  get_from_filelistgz centos-glibc http://mirror.centos.org/centos/ glibc i686
-  get_from_filelistgz centos-glibc http://mirror.centos.org/centos/ glibc x86_64
+  get_from_filelistgz centos-glibc http://mirror.centos.org/centos/ glibc i686 http://debuginfo.centos.org/ 
+  get_from_filelistgz centos-glibc http://mirror.centos.org/centos/ glibc x86_64 http://debuginfo.centos.org/ 
 }
 
 categories[cntr_category]="arch"
 requirements["arch"]="requirements_pkg"
 cntr_category=$((cntr_category + 1))
 arch() {
-  get_all_pkg arch-glibc https://archive.archlinux.org/packages/g/glibc/ libc
-  get_all_pkg arch-lib32-glibc https://archive.archlinux.org/packages/l/lib32-glibc/ libc
+  get_all_pkg arch-glibc https://archive.archlinux.org/packages/g/glibc/ libc glibc
+  get_all_pkg arch-lib32-glibc https://archive.archlinux.org/packages/l/lib32-glibc/ libc glibc
   get_all_pkg arch-musl https://archive.archlinux.org/packages/m/musl/ musl
 }
 
@@ -152,3 +152,4 @@ for category in "$@" ; do
   echo "Downloading/updating $category"
   $category
 done
+

--- a/identify
+++ b/identify
@@ -50,4 +50,5 @@ case "$arg" in
     help
 esac
 
-ls -1 db/*.so | xargs $tool | grep -- "$regex" | perl -n -e '/([^\/: ]+)\.so/&&print "$1\n"'
+ls -1 db/*/*.so | xargs $tool | grep -- "$regex" | perl -n -e '/([^\/: ]+)\.so/&&print "$1\n"'
+

--- a/patch
+++ b/patch
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+patch_requirements() {
+  which realpath 2>&1 1>/dev/null || return
+  which patchelf 2>&1 1>/dev/null || return
+  return 0
+}
+
+if [[ $# -ne 2 ]]; then
+  echo >&2 "Usage: $# id elf"
+  exit 2
+fi
+
+id=$1
+targetelf=$(realpath $2)
+
+cd "$(dirname "$#")"
+. common/libc.sh
+
+ls -1 "db/${id}" >/dev/null 2>&1 || die "Invalid ID '$id'"
+
+interpreters=$(find "db/${id}" -name "ld[-_.][a-zA-Z0-9\.]*\.so*" | grep -v "debug")
+[[ -z "$interpreters" ]] && die "Cannot locate any ld.so"
+choseninterpreter=""
+for interpreter in $interpreters; do
+  if ! (file "$interpreter" | grep -q "ELF\|symbolic link to") ; then
+    continue
+  fi
+  choseninterpreter=$(realpath $interpreter)
+  break
+done
+
+
+patchelf --set-interpreter $choseninterpreter --set-rpath $(realpath "db/${id}") $targetelf 2>&1 1>/dev/null && echo "ELF patched" || echo "ELF patching failed"
+

--- a/patch
+++ b/patch
@@ -1,20 +1,22 @@
 #!/bin/bash
 
 patch_requirements() {
-  which realpath 2>&1 1>/dev/null || return
-  which patchelf 2>&1 1>/dev/null || return
+  which realpath 1>/dev/null 2>&1 || return
+  which patchelf 1>/dev/null 2>&1 || return
   return 0
 }
 
 if [[ $# -ne 2 ]]; then
-  echo >&2 "Usage: $# id elf"
+  echo >&2 "Usage: $# id elf [interpreter_choice] [libc_choice]"
   exit 2
 fi
 
 id=$1
 targetelf=$(realpath $2)
+ldchoice=$3
+libcchoice=$4
 
-cd "$(dirname "$#")"
+cd "$(dirname $0)"
 . common/libc.sh
 
 if ! patch_requirements ; then
@@ -23,17 +25,46 @@ fi
 
 ls -1 "db/${id}" >/dev/null 2>&1 || die "Invalid ID '$id'"
 
-interpreters=$(find "db/${id}" -name "ld[-_.][a-zA-Z0-9\.]*\.so*" | grep -v "debug")
+interpreters=($(find "db/${id}" -name "ld[-_\.][a-zA-Z0-9\.-_]*\.so*" | grep -v "debug"))
 [[ -z "$interpreters" ]] && die "Cannot locate any ld.so"
 choseninterpreter=""
-for interpreter in $interpreters; do
-  if ! (file "$interpreter" | grep -q "ELF\|symbolic link to") ; then
-    continue
+interpretersamount=${#interpreters[@]}
+if [[ -z $ld_choice ]]; then
+  if [[ $interpretersamount -eq 1 ]]; then
+    ldchoice=0
+  else
+    echo "There are multiple interpreters found."
+    for i in "${!interpreters[@]}"; do
+      echo "[$i] -> ${interpreters[$i]}"
+    done
+    echo "Your choice (type any other words to quit):"
+    read ldchoice
   fi
-  choseninterpreter=$(realpath $interpreter)
-  break
-done
+fi
+choseninterpreter=${interpreters[$ldchoice]}
+if ! (file $choseninterpreter | grep -q "ELF\|symbolic link to"); then
+  die "Unknown interpreter"
+fi
 
+libcs=($(find "db/${id}" -name "libc[-_\.][a-zA-Z0-9\._-]*\.so*" | grep -v "debug"))
+chosenlibc=""
+libcamount=${#libcs[@]}
+if [[ -z $libc_choice ]]; then
+  if [[ $libcamount -eq 1 ]]; then
+    libcchoice=0
+  else
+    echo "There are multiple C libraries found."
+	for i in "${!libcs[@]}"; do
+	  echo "[$i] -> ${libcs[$i]}"
+	done
+	echo "Your choice (type any other words to quit):"
+	read libcchoice
+  fi
+fi
+chosenlibc=${libcs[$libcchoice]}
+if ! (file $chosenlibc | grep -q "ELF\|symbolic link to"); then
+  die "Unknown libc"
+fi
 
-patchelf --set-interpreter $choseninterpreter --set-rpath $(realpath "db/${id}") $targetelf 2>&1 1>/dev/null && echo "ELF patched" || echo "ELF patching failed"
+patchelf --set-interpreter $(realpath $choseninterpreter) --replace-needed libc.so.6 $(realpath $chosenlibc) $targetelf 2>&1 1>/dev/null && echo "ELF patched" || echo "ELF patching failed"
 

--- a/patch
+++ b/patch
@@ -17,6 +17,10 @@ targetelf=$(realpath $2)
 cd "$(dirname "$#")"
 . common/libc.sh
 
+if ! patch_requirements ; then
+  die "Patching requires both realpath and patchelf to work"
+fi
+
 ls -1 "db/${id}" >/dev/null 2>&1 || die "Invalid ID '$id'"
 
 interpreters=$(find "db/${id}" -name "ld[-_.][a-zA-Z0-9\.]*\.so*" | grep -v "debug")


### PR DESCRIPTION
This PR is like https://github.com/niklasb/libc-database/pull/39. But I've finished automatic downloading of all platforms.
I've re-organized the structure of the libc database, allowing using debug symbols in different libc with different ID, and also allowing to save other shared object files like ld.so in libc packages for other exploitation like heap exploitation, which is requested in #9 .

The added code has also not been extensively tested. It might work on my machine, but bash is notoriously easy to mess up.
I will test it after the downloading of the libc database. It might not fit into the https://libc.rip website
~~Patching command currently does not support multiple libcs under the same directory. Maybe I need to add interaction to the script later.~~
I've added the support of the multiple libraries under the same directory.

I'm not a native English speaker so there might be grammatical errors or typos in the script or this PR message.

**After this PR, all of the libc databases need to be re-downloaded to fit into the new database structure**
Please wait for the repairing of compatibility of gdb. I have little time to do it because I'm busy with my study.