### PR TITLE
Upgrade to elasticsearch 7.17.7

### DIFF
--- a/searchengine/config.py
+++ b/searchengine/config.py
@@ -2,8 +2,8 @@ import os
 
 ES_INDEX_NAME = 'libcsearch'
 
-# ES_HOST = 'localhost'
-ES_HOST = 'es01'
+# ES_HOST = 'http://localhost:9200'
+ES_HOST = 'http://es01:9200'
 
 # DB_DIR = os.path.dirname(os.path.abspath(__file__)) + '/../db'
 DB_DIR = '/db'

--- a/searchengine/docker-compose.yml
+++ b/searchengine/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         tag: uwsgi
 
   es01:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.7
     container_name: es01
     environment:
       - node.name=es01


### PR DESCRIPTION
This might help prevent the OOM crashes.
Newer elasticsearch-py versions require scheme, host, and port when connecting to a elasticsearch cluster, so the config needs updating.