### PR TITLE
Add arm64/armhf Ubuntu libc support and fix deb unpacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ database:
 
     $ ./get  # List categories
     $ ./get ubuntu debian  # Download Ubuntu's and Debian's libc, old default behavior
+    $ ./get ubuntu-arm  # Download Ubuntu's arm64/armhf libc from ports.ubuntu.com
     $ ./get all  # Download all categories. Can take a while!
 
 You can also add a custom libc to your database.

--- a/common/libc.sh
+++ b/common/libc.sh
@@ -136,7 +136,11 @@ get_all_debian() {
   local info=$1
   local url=$2
   local pkgname=$3
-  for f in `wget $url/ -O - 2>/dev/null | grep -Eoh "$pkgname"'(-i386|-amd64|-x32)?_[^"]*(amd64|i386)\.deb' |grep -v "</a>"`; do
+  # arch is a grep -E alternation of Debian architecture names to match in the
+  # .deb filename, e.g. "amd64|i386" or "arm64|armhf". Defaults to the
+  # traditional x86 architectures for backwards compatibility.
+  local arch="${4:-amd64|i386}"
+  for f in `wget $url/ -O - 2>/dev/null | grep -Eoh "$pkgname"'(-i386|-amd64|-x32|-armel|-armhf|-arm64)?_[^"]*('"$arch"')\.deb' |grep -v "</a>"`; do
     get_debian "$url/$f" "$info" "$pkgname"
   done
   return 0

--- a/common/libc.sh
+++ b/common/libc.sh
@@ -8,7 +8,10 @@ die() {
 }
 
 dump_symbols() {
-  readelf -Ws $1 | perl -n -e '/: (\w+)\s+\w+\s+(?:FUNC|OBJECT)\s+(?:\w+\s+){3}(\w+)\b(?:@@GLIBC)?/ && print "$2 $1\n"' | sort -u
+  # Force byte-order (C locale) sorting: under locale-aware collation (e.g.
+  # en_US.UTF-8), `sort -u` can treat symbols differing only by leading
+  # underscores as equal (e.g. "__dup2" and "dup2"), silently dropping one.
+  readelf -Ws $1 | perl -n -e '/: (\w+)\s+\w+\s+(?:FUNC|OBJECT)\s+(?:\w+\s+){3}(\w+)\b(?:@@GLIBC)?/ && print "$2 $1\n"' | LC_ALL=C sort -u
 }
 
 extract_label() {
@@ -16,9 +19,13 @@ extract_label() {
 }
 
 dump_libc_start_main_ret() {
+  # Match the "call" instruction on the relevant architecture: x86 uses
+  # "call"; ARM/AArch64 use "bl" (direct branch-with-link), "blr" (AArch64
+  # register-indirect branch-with-link) or "blx" (ARM/Thumb register-indirect
+  # branch-with-link, used to call the app-specific main()).
   local call_main=`objdump -D $1 \
     | grep -EA 100 '<__libc_start_main.*>:' \
-    | grep call \
+    | grep -E '\b(call|bl|blr|blx)\b' \
     | grep -EB 1 '<exit.*>' \
     | head -n 1 \
     | extract_label`
@@ -27,7 +34,7 @@ dump_libc_start_main_ret() {
   if [[ "$call_main" == "" ]]; then
     local call_main=`objdump -D $1 \
       | grep -EB 100 '<__libc_start_main.*>:' \
-      | grep call \
+      | grep -E '\b(call|bl|blr|blx)\b' \
       | grep -EB 1 '<exit.*>' \
       | head -n 1 \
       | extract_label`

--- a/download
+++ b/download
@@ -35,8 +35,16 @@ download_single() {
   popd 1>/dev/null
 
   mkdir libs/$id
-  cp $tmp/lib/*/* libs/$id 2>/dev/null || cp $tmp/lib32/* libs/$id 2>/dev/null \
-    || die "Failed to save. Check it manually $tmp"
+  # Depending on the distro/architecture and whether merged-/usr is in use,
+  # the shared libraries can live under lib/<triplet>, usr/lib/<triplet>
+  # (e.g. modern amd64/arm64 packages), lib32 (i386 multiarch on amd64), or
+  # lib64/usr/lib64 (amd64 multiarch on i386, e.g. libc6-amd64).
+  # Only copy regular files (not subdirs like gconv/, audit/), and rely on
+  # find succeeding rather than cp's exit code, since cp exits non-zero
+  # whenever a directory is among its arguments even if all files copied.
+  find $tmp/lib/*/ $tmp/usr/lib/*/ $tmp/lib32/ $tmp/lib64/ $tmp/usr/lib64/ \
+    -maxdepth 1 -type f -exec cp -t libs/$id {} + 2>/dev/null
+  [ "$(ls -A libs/$id 2>/dev/null)" ] || die "Failed to save. Check it manually $tmp"
   echo "  -> Package saved to libs/$id"
 
   rm -rf $tmp

--- a/get
+++ b/get
@@ -24,6 +24,19 @@ ubuntu() {
   get_all_debian ubuntu-old-dietlibc http://old-releases.ubuntu.com/ubuntu/pool/universe/d/dietlibc/ dietlibc
 }
 
+categories[cntr_category]="ubuntu-arm"
+requirements["ubuntu-arm"]="requirements_debian"
+cntr_category=$((cntr_category + 1))
+ubuntu_arm_archs="arm64|armhf"
+ubuntu-arm() {
+  # Ubuntu ports archive hosts arm64/armhf (and other non-x86) builds,
+  # including security updates, all under the same pool directory.
+  get_all_debian ubuntu-arm-eglibc http://ports.ubuntu.com/ubuntu-ports/pool/main/e/eglibc/ libc6 "$ubuntu_arm_archs"
+  get_all_debian ubuntu-arm-glibc http://ports.ubuntu.com/ubuntu-ports/pool/main/g/glibc/ libc6 "$ubuntu_arm_archs"
+  get_all_debian ubuntu-arm-musl http://ports.ubuntu.com/ubuntu-ports/pool/universe/m/musl/ musl "$ubuntu_arm_archs"
+  get_all_debian ubuntu-arm-dietlibc http://ports.ubuntu.com/ubuntu-ports/pool/universe/d/dietlibc/ dietlibc "$ubuntu_arm_archs"
+}
+
 categories[cntr_category]="debian"
 requirements["debian"]="requirements_debian"
 cntr_category=$((cntr_category + 1))


### PR DESCRIPTION
Adds a new ubuntu-arm category to ./get that fetches arm64/armhf glibc/musl/eglibc/dietlibc packages from ports.ubuntu.com, and fixes a bug in ./download where extraction could falsely report failure (and miss usr/lib/<triplet>, lib64 layouts) — verified end-to-end on an arm64 Ubuntu host.